### PR TITLE
Handle primitive types consistently

### DIFF
--- a/ImmutableObject.js
+++ b/ImmutableObject.js
@@ -46,9 +46,7 @@ ImmutableObject.prototype.set = function(props) {
   var propertyDefs = {};
   keys.forEach(function(key) {
     var value = props[key];
-    if (typeof value === "object" && !value.__isImmutableObject__) {
-      value = require("./factory")(value);
-    }
+    value = require("./factory")(value);
     propertyDefs[key] = { value: value, enumerable: true };
   });
   var newObj = Object.create(this, propertyDefs);

--- a/factory.js
+++ b/factory.js
@@ -3,9 +3,11 @@
 var ImmutableObject = require("./ImmutableObject");
 
 function factory(input) {
-  if (input instanceof Array) {
+  if (arguments.length === 0) {
+    return ImmutableObject();
+  } else if (Array.isArray(input)) {
     return Object.freeze(input.map(factory));
-  } else if (typeof input === "object" || typeof input === "undefined") {
+  } else if (typeof input === "object" && input != null) {
     return ImmutableObject(input);
   } else {
     // Treat anything else i.e. number, boolean, null, as immutable already

--- a/tests.js
+++ b/tests.js
@@ -27,8 +27,22 @@ describe("factory", function() {
     assert.equal(obj.a, 1);
   });
 
+  it("returns empty object when no props", function() {
+    assert.equal(Object.keys(immutable()).length, 0);
+  });
+
   it("returns same empty object when no props", function() {
     assert.strictEqual(immutable(), immutable());
+  });
+
+  it("can be called with various primitive types`", function() {
+    var primitives = [false, "hello", 5, null, undefined];
+    primitives.forEach(function(val) {
+      assert.strictEqual(immutable(val), val);
+      var obj = { val: val };
+      assert.strictEqual(immutable({ val: val }).val, val);
+    });
+    assert.deepEqual(immutable(primitives), primitives);
   });
 });
 


### PR DESCRIPTION
This change ensures that any time the factory is called with a primitive type, the primitive value is simply returned. This behavior was previously inconsistent between different primitive types (e.g., `false` would return `false`, `null` would throw an error, `undefined` would return an empty _ImmutableObject_ object). See the commit message for details about the changes.
