### PR TITLE
Miscellaneous bugfixes and improvements

### DIFF
--- a/ImmutableObject.js
+++ b/ImmutableObject.js
@@ -13,7 +13,7 @@ function ImmutableObject(props) {
   return empty.set(props);
 }
 
-var empty = Object.create(ImmutableObject.prototype);
+var empty = Object.freeze(Object.create(ImmutableObject.prototype));
 
 ImmutableObject.prototype.set = function(props) {
   if (!props) {

--- a/ImmutableObject.js
+++ b/ImmutableObject.js
@@ -23,7 +23,7 @@ ImmutableObject.prototype.set = function(props) {
   // allow this.set("property", value)
   // call this.set({property: value})
   if (typeof props === "string") {
-    var propsObj = {}
+    var propsObj = {};
     propsObj[props] = arguments[1];
     return this.set(propsObj);
   }
@@ -67,14 +67,14 @@ ImmutableObject.prototype.unset = function(keyToExclude) {
     return key !== keyToExclude;
   }
 
-  if (this.hasOwnProperty(keyToExclude) && 
+  if (this.hasOwnProperty(keyToExclude) &&
       allKeys(Object.getPrototypeOf(this)).indexOf(keyToExclude) < 0) {
     Object.keys(this).filter(notExcluded).forEach(includeKey, this);
     return Object.getPrototypeOf(this).set(props);
   } else {
     var keys = allKeys(this);
     var filtered = keys.filter(notExcluded);
-    var noChange = filtered.length === keys.length
+    var noChange = filtered.length === keys.length;
     if (noChange) {
       return this;
     } else {
@@ -88,7 +88,7 @@ ImmutableObject.prototype.toJSON = function() {
   var json = {};
   ImmutableObject.keys(this).forEach(function(key) {
     var value = this[key];
-    json[key] = (value && typeof value.toJSON === "function") 
+    json[key] = (value && typeof value.toJSON === "function")
       ? value.toJSON()
       : value;
   }, this);

--- a/ImmutableObject.js
+++ b/ImmutableObject.js
@@ -59,9 +59,9 @@ ImmutableObject.prototype.set = function(props) {
 ImmutableObject.prototype.unset = function(keyToExclude) {
   var props = {};
 
-  function includeKey(key) {
+  var includeKey = function(key) {
     props[key] = this[key];
-  }
+  }.bind(this);
 
   function notExcluded(key) {
     return key !== keyToExclude;
@@ -69,7 +69,7 @@ ImmutableObject.prototype.unset = function(keyToExclude) {
 
   if (this.hasOwnProperty(keyToExclude) &&
       allKeys(Object.getPrototypeOf(this)).indexOf(keyToExclude) < 0) {
-    Object.keys(this).filter(notExcluded).forEach(includeKey, this);
+    Object.keys(this).filter(notExcluded).forEach(includeKey);
     return Object.getPrototypeOf(this).set(props);
   } else {
     var keys = allKeys(this);

--- a/ImmutableObject.js
+++ b/ImmutableObject.js
@@ -28,6 +28,9 @@ ImmutableObject.prototype.set = function(props) {
     return this.set(propsObj);
   }
 
+  var keys = allKeys(props);
+  if (keys.length === 0) return this;
+
   function sameKeys(x, y) {
     return Object.keys(x).every(function(key) {
       return y.hasOwnProperty(key);
@@ -39,9 +42,6 @@ ImmutableObject.prototype.set = function(props) {
     var p = Object.getPrototypeOf(this);
     return p.set(props);
   }
-
-  var keys = allKeys(props);
-  if (keys.length === 0) return this;
 
   var propertyDefs = {};
   keys.forEach(function(key) {

--- a/tests.js
+++ b/tests.js
@@ -63,6 +63,11 @@ describe("set method", function() {
     assert.strictEqual(obj.set(), obj);
   });
 
+  it("returns same object if props are empty", function() {
+    var obj = immutable();
+    assert.strictEqual(obj.set({}), obj);
+  });
+
   it("returns a new object", function() {
     var newObject = obj.set({a:1});
     assert.notStrictEqual(newObject, obj);

--- a/tests.js
+++ b/tests.js
@@ -15,6 +15,8 @@ describe("factory", function() {
 
   it("freezes object", function() {
     assert(Object.isFrozen(obj));
+    assert(Object.isFrozen(immutable()));
+    assert(Object.isFrozen(immutable([])));
   });
 
   it("throws if trying to write property, in strict mode", function() {

--- a/tests.js
+++ b/tests.js
@@ -122,7 +122,20 @@ describe("unset", function() {
     var base = immutable({a:1});
     var current = base.set({b:1});
     var result = current.unset("b");
+    assert.equal(immutable.keys(result).length, 1);
+    assert.equal(immutable.keys(result).indexOf("b"), -1);
+    assert.equal(immutable.keys(result).indexOf("a"), 0);
     assert.strictEqual(result, base);
+  });
+
+  it("creates new object if key is in prototype", function() {
+    var base = immutable({a:1});
+    var current = base.set({b:1});
+    var result = current.unset("a");
+    assert.equal(immutable.keys(result).length, 1);
+    assert.equal(immutable.keys(result).indexOf("a"), -1);
+    assert.equal(immutable.keys(result).indexOf("b"), 0);
+    assert.notStrictEqual(result, base);
   });
 
   it("returns same object if property doesn't exist", function() {


### PR DESCRIPTION
These changes are basically backwards-compatible and simply fixes bugs or unexpected behavior.
- `Object.freeze()` the _ImmutableObject_ empty object
- Add missing semicolons and remove trailing whitespace
- Fix bug with `unset()` due to wrong `this` context and add more tests around `unset()`
- Fix bug with `set({})` where an empty object caused invalid traversal of the prototype chain

See individual commit messages for more details.
