### PR TITLE
Add arrayWhere method to lens.

### DIFF
--- a/lens.js
+++ b/lens.js
@@ -71,13 +71,13 @@ function arrayItem(index) {
   };
 }
 
-function arrayWhere(property, value) {
+function arrayWhere(filterFn) {
   return {
     get: function(array) {
       for (var i = 0, l = array.length; i < l; i++) {
         var item = array[i];
 
-        if (item[property] === value) {
+        if (filterFn(item)) {
           return item;
         }
       }
@@ -87,7 +87,7 @@ function arrayWhere(property, value) {
       for (var i = 0, l = array.length; i < l; i++) {
         var item = array[i];
 
-        if (item[property] === value) {
+        if (filterFn(item)) {
           return array
             .slice(0, i)
             .concat(newItem)

--- a/lens.js
+++ b/lens.js
@@ -66,7 +66,34 @@ function arrayItem(index) {
       return array
         .slice(0, index)
         .concat(newItem)
-        .concat(array.slice(index + 1)); 
+        .concat(array.slice(index + 1));
+    }
+  };
+}
+
+function arrayWhere(property, value) {
+  return {
+    get: function(array) {
+      for (var i = 0, l = array.length; i < l; i++) {
+        var item = array[i];
+
+        if (item[property] === value) {
+          return item;
+        }
+      }
+    },
+
+    set: function(array, newItem) {
+      for (var i = 0, l = array.length; i < l; i++) {
+        var item = array[i];
+
+        if (item[property] === value) {
+          return array
+            .slice(0, i)
+            .concat(newItem)
+            .concat(array.slice(i + 1));
+        }
+      }
     }
   };
 }
@@ -119,6 +146,7 @@ function extend(target, props) {
 }
 
 exports.arrayItem = arrayItem;
+exports.arrayWhere = arrayWhere;
 exports.prop = prop;
 exports.compose = composeLenses;
 exports.update = update;

--- a/tests.js
+++ b/tests.js
@@ -280,6 +280,20 @@ describe("lens.arrayItem", function() {
   });
 });
 
+describe("lens.arrayWhere", function() {
+  var original = [{id: "a"}, {id: "b"}, {id: "c"}];
+  var item1 = lens.arrayWhere("id", "b");
+
+  it("can get item", function() {
+    assert.deepEqual(item1.get(original), {id: "b"});
+  });
+
+  it("can set item", function() {
+    var newArray = item1.set(original, {id: "z"});
+    assert.deepEqual(newArray, [{id: "a"}, {id: "z"}, {id: "c"}]);
+  });
+});
+
 describe("composed lenses with lens.compose", function() {
   var foo = lens.prop("foo");
   var bar = lens.prop("bar");
@@ -375,7 +389,7 @@ describe("lens.build", function() {
   describe("object -> array -> object -> array", function() {
     var l = lens.build({
       a: [
-        { b: [] } 
+        { b: [] }
       ]
     });
     var target = immutable({

--- a/tests.js
+++ b/tests.js
@@ -282,7 +282,9 @@ describe("lens.arrayItem", function() {
 
 describe("lens.arrayWhere", function() {
   var original = [{id: "a"}, {id: "b"}, {id: "c"}];
-  var item1 = lens.arrayWhere("id", "b");
+  var item1 = lens.arrayWhere(function(item) {
+    return item.id === "b"
+  });
 
   it("can get item", function() {
     assert.deepEqual(item1.get(original), {id: "b"});


### PR DESCRIPTION
This adds `lens.arrayWhere` which makes it simple to create lenses that target array items by propery value.

``` javascript
var data = immutable([
  {id: "a", name: "Foo"},
  {id: "b", name: "Bar"}
])

var aLens = lens.arrayWhere("id", "a")
console.log(aLens.get(data).name)

var aNameLens = lens.compose(aLens, lens.prop("name"))
var newData = aNameLens.set(data, "Faz")

console.log(aLens.get(newData).name)
```

There's definitely room for improvement as far as the implementation goes, I chose to go for speed rather than implementing the loops with `Array.some`.

In addition it might be interesting to implement a check for the first parameter, if it's a function use it to locate the correct array element.
