### PR TITLE
Make `__isImmutableObject__` flag not enumerable

### DIFF
--- a/ImmutableObject.js
+++ b/ImmutableObject.js
@@ -93,7 +93,10 @@ ImmutableObject.prototype.toJSON = function() {
   return json;
 };
 
-ImmutableObject.prototype.__isImmutableObject__ = true;
+Object.defineProperty(ImmutableObject.prototype, "__isImmutableObject__", {
+  enumerable: false,
+  value: true,
+});
 
 Object.freeze(ImmutableObject.prototype);
 


### PR DESCRIPTION
This changes `ImmutableObject.prototype.__isImmutableObject__` to be defined as a non-enumerable property of the ImmutableObject prototype instead of being defined by assignment (which results in an enumerable property).
